### PR TITLE
Fix redirect filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 /node_modules
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased] 
+
+### Added
+- This changelog
+
+### Modified
+- Added parameter-parameters to add_filter to prevent warning.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - This changelog
 
-### Modified
-- Added parameter-parameters to add_filter to prevent warning.
+### Changed
+- Revert back to wp_send_json, since after JSON is sent die is required and the filter is therefore unnecessary. 

--- a/classes/comments.php
+++ b/classes/comments.php
@@ -304,7 +304,7 @@ class Comments extends \DustPress\Helper {
 
         echo json_encode( $return );
 
-        add_filter( 'comment_post_redirect', array( $this, 'prevent_redirect' ) );
+        add_filter( 'comment_post_redirect', array( $this, 'prevent_redirect' ), 10, 2 );
     }
 
     /**

--- a/classes/comments.php
+++ b/classes/comments.php
@@ -302,20 +302,7 @@ class Comments extends \DustPress\Helper {
             'html'      => $output,
         ];
 
-        echo json_encode( $return );
-
-        add_filter( 'comment_post_redirect', array( $this, 'prevent_redirect' ), 10, 2 );
-    }
-
-    /**
-     * Prevents WordPress from making a redirect to the AJAX call when we don't want it to.
-     *
-     * @param string $original Original redirect url. Not needed.
-     * @param string $comment The comment that was sent.
-     * @return void
-     */
-    public function prevent_redirect( $original, $comment ) {
-        die();
+        wp_send_json( $return );
     }
 
     /**


### PR DESCRIPTION
Revert back to wp_send_json, since after JSON is sent die is required and the filter is therefore unnecessary. 

Fixes issue #9 and warning about undefined function parameters.